### PR TITLE
Fix system-ui-controller package name

### DIFF
--- a/extensions-compose-system-ui-controller/src/main/java/tech/thdev/compose/extensions/system/ui/controller/SystemUiController.kt
+++ b/extensions-compose-system-ui-controller/src/main/java/tech/thdev/compose/extensions/system/ui/controller/SystemUiController.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package tech.thdev.compose.exteions.system.ui.controller
+package tech.thdev.compose.extensions.system.ui.controller
 
 import android.app.Activity
 import android.content.Context


### PR DESCRIPTION
패키지내에 exteions 오타를 extensions로 정정하였습니다.

tech.thdev.compose.exteions.system.ui.controller.rememberSystemUiController
-> tech.thdev.compose.extensions.system.ui.controller.rememberSystemUiController